### PR TITLE
mobile navigation menu added

### DIFF
--- a/packages/client/src/components/MobileNavigation/MobileNavigation.component.js
+++ b/packages/client/src/components/MobileNavigation/MobileNavigation.component.js
@@ -1,9 +1,8 @@
 import React, { useState } from 'react';
-import PropTypes from 'prop-types';
 import './MobileNavigation.css';
 
-export const MobileNavigation = ({ isOpenStory, ...props }) => {
-  const [isOpen, setIsOpen] = useState(isOpenStory);
+export const MobileNavigation = () => {
+  const [isOpen, setIsOpen] = useState(false);
   function openMobileNav() {
     setIsOpen(true);
   }
@@ -38,11 +37,4 @@ export const MobileNavigation = ({ isOpenStory, ...props }) => {
       </div>
     </div>
   );
-};
-
-MobileNavigation.propTypes = {
-  isOpenStory: PropTypes.bool,
-};
-MobileNavigation.defaultProps = {
-  isOpenStory: false,
 };

--- a/packages/client/src/components/MobileNavigation/MobileNavigation.component.js
+++ b/packages/client/src/components/MobileNavigation/MobileNavigation.component.js
@@ -1,0 +1,48 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import './MobileNavigation.css';
+
+export const MobileNavigation = ({ isOpenStory, ...props }) => {
+  const [isOpen, setIsOpen] = useState(isOpenStory);
+  function openMobileNav() {
+    setIsOpen(true);
+  }
+  function closeMobileNav() {
+    setIsOpen(false);
+  }
+  return (
+    <div
+      className={`mobile-navigation-container ${
+        isOpen ? 'mobile-navigation-container--opened' : ' '
+      }`}
+    >
+      <button
+        type="button"
+        className="mobile-navbar-btn"
+        onClick={openMobileNav}
+      >
+        icon
+      </button>
+      <div className="mobile-navbar-links-wrapper">
+        <button
+          type="button"
+          className="mobile-navbar-btn"
+          onClick={closeMobileNav}
+        >
+          icon
+        </button>
+        <nav className="mobile-navigation">
+          <a href="/about-toolbox">about toolbox</a>
+          <a href="/contact-us">contact us</a>
+        </nav>
+      </div>
+    </div>
+  );
+};
+
+MobileNavigation.propTypes = {
+  isOpenStory: PropTypes.bool,
+};
+MobileNavigation.defaultProps = {
+  isOpenStory: false,
+};

--- a/packages/client/src/components/MobileNavigation/MobileNavigation.css
+++ b/packages/client/src/components/MobileNavigation/MobileNavigation.css
@@ -1,0 +1,54 @@
+@import url('https://fonts.googleapis.com/css2?family=Open+Sans&display=swap');
+
+.mobile-navigation-container .mobile-navbar-links-wrapper {
+  background: linear-gradient(180deg, rgba(28, 56, 64, 0.7) 0%, rgba(28, 65, 64, 0.7) 0.01%, rgba(28, 65, 64, 0.7) 100%),
+    url("../../../public/assets/images/body-background-image-concrete.png");
+  background-repeat: repeat;
+  position: absolute;
+  top: 0;
+  left: 0;
+  transition: all 0.666s ease-out;
+  width: 100vw;
+  height: 0;
+
+}
+
+.mobile-navigation {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 10vh;
+}
+
+.mobile-navigation a {
+  font-size: 1.5rem;
+  color: rgb(255, 255, 255);
+  text-decoration: none;
+  font-family: 'Open Sans';
+}
+
+.mobile-navbar-btn {
+  border: none;
+  background: none;
+  border-radius: 0;
+  cursor: pointer;
+  padding: 0;
+  aspect-ratio: 1/1;
+}
+
+.mobile-navbar-links-wrapper .mobile-navbar-btn {
+  opacity: 0;
+  transition: opacity 0.2s ease-out;
+  display: block;
+  margin-left: auto;
+  margin-top: 1rem;
+  margin-right: 1rem;
+}
+
+.mobile-navigation-container--opened .mobile-navbar-links-wrapper .mobile-navbar-btn {
+  opacity: 1;
+}
+
+.mobile-navigation-container.mobile-navigation-container--opened .mobile-navbar-links-wrapper {
+  height: 100vh;
+}

--- a/packages/client/src/components/MobileNavigation/MobileNavigation.stories.js
+++ b/packages/client/src/components/MobileNavigation/MobileNavigation.stories.js
@@ -6,9 +6,6 @@ export default {
   title: 'Mobile Navigation Menu',
   component: MobileNavigation.component,
 };
-const TemplateMobileNavigataion = (args) => <MobileNavigation {...args} />;
+const TemplateMobileNavigataion = () => <MobileNavigation />;
 
 export const mobileNavigataionOpened = TemplateMobileNavigataion.bind({});
-mobileNavigataionOpened.args = {
-  isOpenStory: true,
-};

--- a/packages/client/src/components/MobileNavigation/MobileNavigation.stories.js
+++ b/packages/client/src/components/MobileNavigation/MobileNavigation.stories.js
@@ -1,0 +1,14 @@
+import React from 'react';
+
+import { MobileNavigation } from './MobileNavigation.component';
+
+export default {
+  title: 'Mobile Navigation Menu',
+  component: MobileNavigation.component,
+};
+const TemplateMobileNavigataion = (args) => <MobileNavigation {...args} />;
+
+export const mobileNavigataionOpened = TemplateMobileNavigataion.bind({});
+mobileNavigataionOpened.args = {
+  isOpenStory: true,
+};


### PR DESCRIPTION
Mobile navigation is a component that has to appear on the small screen with. It has two buttons to show and hide the menu. 
Icons will be placed later.

# How to test?
Run Storybook and try to click open and close buttons.

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have followed the name conventions for CSS Classnames and filenames, Components names and filenames, Style filenames, if you are in doubt check the the project README.MD and here https://github.com/HackYourFuture-CPH/curriculum/blob/master/review/review-checklist.md
- [x] I have commented my code, particularly in hard-to-understand areas, if you code was simple enough mark the box anyway
- [x] I have made corresponding changes to the documentation, if you code was simple enough mark the box anyway
- [x] This PR is ready to be merged and not breaking any other functionality
