### PR TITLE
bugfix/container-is-restricted-in-height

### DIFF
--- a/packages/client/src/components/Main/Main.css
+++ b/packages/client/src/components/Main/Main.css
@@ -1,9 +1,5 @@
 main {
-  background: linear-gradient(180deg,
-      rgba(28, 56, 64, 0.7) 0%,
-      rgba(28, 65, 64, 0.8) 0.01%,
-      rgba(7, 27, 32, 0.5) 100%),
-    url('../../../public/assets/images/body-background-image-concrete.png');
+  background: linear-gradient(180deg, rgba(28, 56, 64, 0.7) 0%, rgba(28, 65, 64, 0.8) 0.01%, rgba(7, 27, 32, 0.5) 100%), url('../../../public/assets/images/body-background-image-concrete.png');
   background-repeat: repeat;
   min-height: 100vh;
 }

--- a/packages/client/src/components/Main/Main.css
+++ b/packages/client/src/components/Main/Main.css
@@ -1,20 +1,19 @@
 main {
-  background: linear-gradient(
-      180deg,
+  background: linear-gradient(180deg,
       rgba(28, 56, 64, 0.7) 0%,
       rgba(28, 65, 64, 0.8) 0.01%,
-      rgba(7, 27, 32, 0.5) 100%
-    ),
+      rgba(7, 27, 32, 0.5) 100%),
     url('../../../public/assets/images/body-background-image-concrete.png');
   background-repeat: repeat;
-  height: 100vh;
+  min-height: 100vh;
 }
 
 .main-container {
   background: rgba(245, 245, 245, 0.05);
   width: 1220px;
   margin: auto;
-  height: 100vh;
+  min-height: 100vh;
+  padding-top: 6rem;
 }
 
 @media screen and (max-width: 1300px) {

--- a/packages/client/src/components/Main/Main.css
+++ b/packages/client/src/components/Main/Main.css
@@ -1,5 +1,11 @@
 main {
-  background: linear-gradient(180deg, rgba(28, 56, 64, 0.7) 0%, rgba(28, 65, 64, 0.8) 0.01%, rgba(7, 27, 32, 0.5) 100%), url('../../../public/assets/images/body-background-image-concrete.png');
+  background: linear-gradient(
+      180deg,
+      rgba(28, 56, 64, 0.7) 0%,
+      rgba(28, 65, 64, 0.8) 0.01%,
+      rgba(7, 27, 32, 0.5) 100%
+    ),
+    url('../../../public/assets/images/body-background-image-concrete.png');
   background-repeat: repeat;
   min-height: 100vh;
 }


### PR DESCRIPTION
Changed height property of the main container to fix its height restriction.
Added padding-top to the main container to prevent overlapping content by navigation, because navigation now has position:fixed.

# How to test?

Put some content in the main container to see that its height is not restricted.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the name conventions for CSS Classnames and filenames, Components names and filenames, Style filenames, if you are in doubt check the the project README.MD and here https://github.com/HackYourFuture-CPH/curriculum/blob/master/review/review-checklist.md
- [x] I have commented my code, particularly in hard-to-understand areas, if you code was simple enough mark the box anyway
- [x] I have made corresponding changes to the documentation, if you code was simple enough mark the box anyway
- [x] This PR is ready to be merged and not breaking any other functionality
