### PR TITLE
Remove npm engine to advance in heroku build step

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
     "packages/*"
   ],
   "engines": {
-    "npm": "please-use-yarn",
     "yarn": ">= 1.19.1",
     "node": ">= 16.15.1"
   },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "stylelint:fix": "yarn stylelint \"**/*.css\" --fix",
     "validate": "yarn prettier:check && yarn lint && yarn stylelint:check",
     "fix": "yarn prettier:fix && yarn lint:fix && yarn stylelint:fix",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "heroku-postbuild": "yarn workspace client build && cp -a packages/client/build/. packages/server/public/"
   },
   "devDependencies": {
     "eslint-plugin-prettier": "^4.0.0",

--- a/packages/server/app.js
+++ b/packages/server/app.js
@@ -16,4 +16,10 @@ app.use(express.static(path.join(__dirname, 'public')));
 
 app.use(`/api/`, router);
 
+// Handle every other route with index.html, which will serve the (compiled) React app.
+const serveSpa = function (request, response) {
+  response.sendFile(path.resolve(__dirname, 'public', 'index.html'));
+};
+app.get('*', serveSpa);
+
 module.exports = app;


### PR DESCRIPTION
# Description

A first attempt at fixing the heroku release.

- Removes the invalid `npm` `engine` declaration that heroku is unhappy about
- Adds client-side building in `heroku-postbuild` script. https://github.com/HackYourFuture-CPH/fp-class20/pull/120/files
- Adds serving of the client via the a catchall route on the server. https://github.com/HackYourFuture-CPH/fp-class20/pull/135

# How to test?

N/A

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the name conventions for CSS Classnames and filenames, Components names and filenames, Style filenames, if you are in doubt check the the project README.MD and here https://github.com/HackYourFuture-CPH/curriculum/blob/master/review/review-checklist.md
- [x] I have commented my code, particularly in hard-to-understand areas, if you code was simple enough mark the box anyway
- [x] I have made corresponding changes to the documentation, if you code was simple enough mark the box anyway
- [x] This PR is ready to be merged and not breaking any other functionality
