### PR TITLE
FP21-76:Fix routing to tool page

### DIFF
--- a/packages/client/src/components/ToolDetailPage/ToolDetailPage.component.js
+++ b/packages/client/src/components/ToolDetailPage/ToolDetailPage.component.js
@@ -1,5 +1,0 @@
-import React from 'react';
-
-export const ToolDetailPage = () => {
-  return <div>Product Details will be showen here</div>;
-};

--- a/packages/client/src/components/ToolItem/ToolItem.component.js
+++ b/packages/client/src/components/ToolItem/ToolItem.component.js
@@ -95,7 +95,7 @@ export const ToolItem = ({
       </div>
       <div className="button-container">
         <button type="button" className="tool-button">
-          <Link to={`/tools/${"id"}`}>VIEW TOOL</Link>
+          <Link to={`/tools/${'id'}`}>VIEW TOOL</Link>
         </button>
       </div>
     </div>

--- a/packages/client/src/components/ToolItem/ToolItem.component.js
+++ b/packages/client/src/components/ToolItem/ToolItem.component.js
@@ -95,7 +95,7 @@ export const ToolItem = ({
       </div>
       <div className="button-container">
         <button type="button" className="tool-button">
-          <Link to={`/tools/${id}`}>VIEW TOOL</Link>
+          <Link to={`/tools/${"id"}`}>VIEW TOOL</Link>
         </button>
       </div>
     </div>

--- a/packages/client/src/components/ToolItem/ToolItem.component.js
+++ b/packages/client/src/components/ToolItem/ToolItem.component.js
@@ -95,7 +95,7 @@ export const ToolItem = ({
       </div>
       <div className="button-container">
         <button type="button" className="tool-button">
-          <Link to="/ToolDetailPage">VIEW TOOL</Link>
+          <Link to={`/tools/${id}`}>VIEW TOOL</Link>
         </button>
       </div>
     </div>

--- a/packages/client/src/containers/PageNotFound/PageNotFound.Container.js
+++ b/packages/client/src/containers/PageNotFound/PageNotFound.Container.js
@@ -6,7 +6,6 @@ export const PageNotFound = () => {
   return (
     <div className="page-not-found-container">
       <span>Page Not Found</span>
-      <ToolDetailsPage />
     </div>
   );
 };

--- a/packages/client/src/containers/PageNotFound/PageNotFound.Container.js
+++ b/packages/client/src/containers/PageNotFound/PageNotFound.Container.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import './PageNotFound.Style.css';
-import { ToolDetailsPage } from '../../components/ToolDetailsPage/ToolDetailsPage.component';
 
 export const PageNotFound = () => {
   return (

--- a/packages/client/src/containers/PageNotFound/PageNotFound.Container.js
+++ b/packages/client/src/containers/PageNotFound/PageNotFound.Container.js
@@ -1,10 +1,12 @@
 import React from 'react';
 import './PageNotFound.Style.css';
+import { ToolDetailsPage } from '../../components/ToolDetailsPage/ToolDetailsPage.component';
 
 export const PageNotFound = () => {
   return (
     <div className="page-not-found-container">
       <span>Page Not Found</span>
+      <ToolDetailsPage/>
     </div>
   );
 };

--- a/packages/client/src/containers/PageNotFound/PageNotFound.Container.js
+++ b/packages/client/src/containers/PageNotFound/PageNotFound.Container.js
@@ -6,7 +6,7 @@ export const PageNotFound = () => {
   return (
     <div className="page-not-found-container">
       <span>Page Not Found</span>
-      <ToolDetailsPage/>
+      <ToolDetailsPage />
     </div>
   );
 };


### PR DESCRIPTION
# Description

The name of the branch is wrong, it’s should be "FP21-76-fix-routing-to-tool-page"
Fix routing to tool page & deleted the ToolDetailsPage file from PageNotFund Because i added it by mistake 
Deleted ToolDetailPage folder 

Fixes # (issue)

# How to test?

0-) run "docker compose up"
1-)run "yarn start server" in the backend.
2-) run "yarn start" in the frontend.
3-) you can see the (VIEW TOOL) in the tool cards click on it .

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the name conventions for CSS Classnames and filenames, Components names and filenames, Style filenames, if you are in doubt check the the project README.MD and here https://github.com/HackYourFuture-CPH/curriculum/blob/master/review/review-checklist.md
- [x] I have commented my code, particularly in hard-to-understand areas, if you code was simple enough mark the box anyway
- [x] I have made corresponding changes to the documentation, if you code was simple enough mark the box anyway
- [x] This PR is ready to be merged and not breaking any other functionality
