### PR TITLE
FP21-71-favourites-endpoints

### DIFF
--- a/packages/client/src/App.js
+++ b/packages/client/src/App.js
@@ -5,6 +5,7 @@ import { LandingPage } from './containers/LandingPage/LandingPage.Container';
 import { PageNotFound } from './containers/PageNotFound/PageNotFound.Container';
 import { Navbar } from './components/Navigation/Navbar.component';
 import { Main } from './components/Main/Main';
+import { FavouritePage } from './components/FavoritesToolPage/FavoritesToolPage.component';
 import { ToolDetailsPage } from './components/ToolDetailsPage/ToolDetailsPage.component';
 import { Footer } from './components/Footer/Footer.component';
 
@@ -24,7 +25,7 @@ function App() {
             <Route path="/user-name" element="" />
             <Route path="/sign-in" element="" />
             <Route path="/sign-out" element="" />
-            <Route path="/favourites" element="" />
+            <Route path="/favourites" element={<FavouritePage />} />
           </Routes>
         </Main>
         <Footer />

--- a/packages/client/src/components/FavoritesToolPage/FavoritesToolPage.component.js
+++ b/packages/client/src/components/FavoritesToolPage/FavoritesToolPage.component.js
@@ -1,0 +1,71 @@
+import React, { useState, useEffect, useMemo } from 'react';
+import getApiBaseUrl from '../../utils/getApiBaseURL';
+import { ToolItem } from '../ToolItem/ToolItem.component';
+import { Sorting } from '../Sorting/Sorting.component';
+
+const userId = 1;
+
+export const FavouritePage = () => {
+  const [Favourites, setFavourites] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [selected, setSelected] = useState('');
+
+  useEffect(() => {
+    async function fetchFavourites() {
+      try {
+        setIsLoading(true);
+        const response = await fetch(
+          `${getApiBaseUrl()}/api/favourites/${userId}`,
+        );
+        const favoritesJson = await response.json();
+        setFavourites(favoritesJson);
+        setIsLoading(false);
+      } catch (error) {
+        setIsLoading(false);
+        throw error;
+      }
+    }
+    fetchFavourites();
+  }, []);
+
+  const sortedTools = useMemo(() => {
+    let result = Favourites;
+    if (selected === 'a-z') {
+      result = result.sort((a, b) => {
+        const titleA = a.name.toUpperCase();
+        const titleB = b.name.toUpperCase();
+        if (titleA < titleB) {
+          return -1;
+        }
+        if (titleA > titleB) {
+          return 1;
+        }
+        return 0;
+      });
+    } else if (selected === 'date') {
+      result = result.sort((a, b) => {
+        const dateA = new Date(a.created_at);
+        const dateB = new Date(b.created_at);
+        return dateB - dateA;
+      });
+    }
+    return result;
+  }, [Favourites, selected]);
+
+  const toolsToRender = isLoading ? (
+    <p>Loading...</p>
+  ) : (
+    <>
+      {sortedTools.map((tool, i) => {
+        return <ToolItem index={i} key={tool.id} tool={tool} />;
+      })}
+    </>
+  );
+
+  return (
+    <div>
+      <Sorting setSelected={setSelected} />
+      <div className="grid-tools-container">{toolsToRender}</div>
+    </div>
+  );
+};

--- a/packages/client/src/components/FavoritesToolPage/FavoritesToolPage.component.js
+++ b/packages/client/src/components/FavoritesToolPage/FavoritesToolPage.component.js
@@ -3,6 +3,7 @@ import getApiBaseUrl from '../../utils/getApiBaseURL';
 import { ToolItem } from '../ToolItem/ToolItem.component';
 import { Sorting } from '../Sorting/Sorting.component';
 
+// using this user_id needed before Firebase implemented
 const userId = 1;
 
 export const FavouritePage = () => {

--- a/packages/client/src/components/FavoritesToolPage/FavoritesToolPage.component.js
+++ b/packages/client/src/components/FavoritesToolPage/FavoritesToolPage.component.js
@@ -7,7 +7,7 @@ import { Sorting } from '../Sorting/Sorting.component';
 const userId = 1;
 
 export const FavouritePage = () => {
-  const [Favourites, setFavourites] = useState([]);
+  const [favourites, setFavourites] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
   const [selected, setSelected] = useState('');
 
@@ -30,7 +30,7 @@ export const FavouritePage = () => {
   }, []);
 
   const sortedTools = useMemo(() => {
-    let result = Favourites;
+    let result = favourites;
     if (selected === 'a-z') {
       result = result.sort((a, b) => {
         const titleA = a.name.toUpperCase();
@@ -43,7 +43,8 @@ export const FavouritePage = () => {
         }
         return 0;
       });
-    } else if (selected === 'date') {
+    }
+    if (selected === 'date') {
       result = result.sort((a, b) => {
         const dateA = new Date(a.created_at);
         const dateB = new Date(b.created_at);
@@ -51,7 +52,7 @@ export const FavouritePage = () => {
       });
     }
     return result;
-  }, [Favourites, selected]);
+  }, [favourites, selected]);
 
   const toolsToRender = isLoading ? (
     <p>Loading...</p>

--- a/packages/client/src/components/ToolItem/ToolItem.component.js
+++ b/packages/client/src/components/ToolItem/ToolItem.component.js
@@ -1,24 +1,64 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import './ToolItem.style.css';
 import { Link } from 'react-router-dom';
+import getApiBaseUrl from '../../utils/getApiBaseURL';
 
 export const ToolItem = ({ tool }) => {
   const title = tool.name;
   const { picture } = tool;
+  const { id } = tool;
   const timeFrameMin = tool.time_frame_min;
   const timeFrameMax = tool.time_frame_max;
   const groupSizeMin = tool.group_size_min;
   const groupSizeMax = tool.group_size_max;
   const { pitch } = tool;
   const { categories } = tool;
+
   const [isFavourite, setIsFavourite] = useState(false);
 
+  // using this user_id needed before Firebase implemented
+  const userId = 1;
+
   const handleChangeFavourite = () => {
-    setIsFavourite((previousIcon) => {
-      return !previousIcon;
-    });
+    if (isFavourite) {
+      fetch(`${getApiBaseUrl()}/api/favourites`, {
+        method: 'DELETE',
+        body: JSON.stringify({ user_id: userId, tool_id: id }),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }).then((result) => {
+        if (result.ok) {
+          setIsFavourite(false);
+        }
+      });
+    } else {
+      fetch(`${getApiBaseUrl()}/api/favourites`, {
+        method: 'POST',
+        body: JSON.stringify({ user_id: userId, tool_id: id }),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }).then((result) => {
+        if (result.ok) {
+          setIsFavourite(true);
+        }
+      });
+    }
   };
+
+  useEffect(() => {
+    fetch(`${getApiBaseUrl()}/api/favourites/${userId}`)
+      .then((response) => response.json())
+      .then((result) => {
+        const filteredResult = result.filter((item) => item.id === id);
+        if (filteredResult.length > 0) {
+          setIsFavourite(true);
+        }
+      });
+  }, [id]);
+
   const availableCategories = ['Innovation', 'Action', 'Energizer', 'Team'];
   const categoriesStreakOut = availableCategories.map((category) => {
     return categories.includes(category) ? (
@@ -76,7 +116,7 @@ export const ToolItem = ({ tool }) => {
       </div>
       <div className="button-container">
         <button type="button" className="tool-button">
-          <Link to={`/tools/${'id'}`}>VIEW TOOL</Link>
+          <Link to={`/tools/${id}`}>VIEW TOOL</Link>
         </button>
       </div>
     </div>
@@ -85,6 +125,7 @@ export const ToolItem = ({ tool }) => {
 
 ToolItem.propTypes = {
   tool: PropTypes.arrayOf(PropTypes.objectOf(PropTypes.string)),
+  id: PropTypes.number,
   name: PropTypes.string,
   time_frame_min: PropTypes.number,
   time_frame_max: PropTypes.number,
@@ -97,6 +138,7 @@ ToolItem.propTypes = {
 
 ToolItem.defaultProps = {
   tool: [],
+  id: null,
   name: null,
   time_frame_min: null,
   time_frame_max: null,

--- a/packages/server/api/controllers/favourites.controller.js
+++ b/packages/server/api/controllers/favourites.controller.js
@@ -33,11 +33,11 @@ const getAllUsersFavourites = async (userId) => {
   return favourites;
 };
 
-const deleteFavourites = async (toolId, userId, body) => {
+const deleteFavourites = async (body) => {
   const favourites = await knex('favourites')
-    .delete(body)
-    .where({ tool_id: toolId })
-    .andWhere({ user_id: userId });
+    .where({ tool_id: body.tool_id })
+    .andWhere({ user_id: body.user_id })
+    .del();
   return favourites;
 };
 

--- a/packages/server/api/controllers/favourites.controller.js
+++ b/packages/server/api/controllers/favourites.controller.js
@@ -5,14 +5,31 @@ const postFavorites = async (body) => {
   return favourites;
 };
 
-const getAllFavourites = async () => {
+const getAllFavourites = async (userId) => {
   const favourites = await knex('tools')
-    .select('*')
+    .select(
+      'tools.id',
+      'tools.name',
+      knex.raw('GROUP_CONCAT (categories.name) as categories'),
+      'tools.time_frame_min',
+      'tools.time_frame_max',
+      'tools.group_size_min',
+      'tools.group_size_max',
+      'tools.facilitation_level',
+      'tools.materials',
+      'tools.pitch',
+      'tools.description',
+      'tools.instructions',
+      'tools.source',
+      'tools.picture',
+      'tools.created_at',
+    )
     .join('favourites', 'favourites.tool_id', '=', 'tools.id')
     .join('users', 'users.id', '=', 'favourites.user_id')
     .join('tools_categories', 'tools_categories.tool_id', '=', 'tools.id')
     .join('categories', 'tools_categories.category_id', '=', 'categories.id')
-    .where('users.id', '=', '3');
+    .where('users.id', '=', userId)
+    .groupBy('tools.id');
   return favourites;
 };
 

--- a/packages/server/api/controllers/favourites.controller.js
+++ b/packages/server/api/controllers/favourites.controller.js
@@ -5,7 +5,7 @@ const postFavorites = async (body) => {
   return favourites;
 };
 
-const getAllFavourites = async (userId) => {
+const getAllUsersFavourites = async (userId) => {
   const favourites = await knex('tools')
     .select(
       'tools.id',
@@ -43,6 +43,6 @@ const deleteFavourites = async (toolId, userId, body) => {
 
 module.exports = {
   postFavorites,
-  getAllFavourites,
+  getAllUsersFavourites,
   deleteFavourites,
 };

--- a/packages/server/api/controllers/favourites.controller.js
+++ b/packages/server/api/controllers/favourites.controller.js
@@ -1,0 +1,29 @@
+const knex = require('../../config/db');
+
+// const postFavorites = async (req, res) => {
+//   try {
+//     const newFavourite = await knex('favourites').insert(req.body);
+//     res.send(`Added new favourite: ${newFavourite}`);
+//   } catch (error) {
+//     res.status(400).send('Cannot add');
+//   }
+// };
+
+const postFavorites = async (body) => {
+  const favourites = await knex('favourites').insert(body);
+  return favourites;
+};
+
+const getAllFavourites = async () => {
+  const favourites = await knex('favourites').select('*');
+  return favourites;
+};
+
+const getFavouriteById = async () => {
+  const favourites = await knew('favourites').join();
+};
+
+module.exports = {
+  postFavorites,
+  getAllFavourites,
+};

--- a/packages/server/api/controllers/favourites.controller.js
+++ b/packages/server/api/controllers/favourites.controller.js
@@ -1,29 +1,31 @@
 const knex = require('../../config/db');
 
-// const postFavorites = async (req, res) => {
-//   try {
-//     const newFavourite = await knex('favourites').insert(req.body);
-//     res.send(`Added new favourite: ${newFavourite}`);
-//   } catch (error) {
-//     res.status(400).send('Cannot add');
-//   }
-// };
-
 const postFavorites = async (body) => {
   const favourites = await knex('favourites').insert(body);
   return favourites;
 };
 
 const getAllFavourites = async () => {
-  const favourites = await knex('favourites').select('*');
+  const favourites = await knex('tools')
+    .select('*')
+    .join('favourites', 'favourites.tool_id', '=', 'tools.id')
+    .join('users', 'users.id', '=', 'favourites.user_id')
+    .join('tools_categories', 'tools_categories.tool_id', '=', 'tools.id')
+    .join('categories', 'tools_categories.category_id', '=', 'categories.id')
+    .where('users.id', '=', '3');
   return favourites;
 };
 
-const getFavouriteById = async () => {
-  const favourites = await knew('favourites').join();
+const deleteFavourites = async (toolId, userId, body) => {
+  const favourites = await knex('favourites')
+    .delete(body)
+    .where({ tool_id: toolId })
+    .andWhere({ user_id: userId });
+  return favourites;
 };
 
 module.exports = {
   postFavorites,
   getAllFavourites,
+  deleteFavourites,
 };

--- a/packages/server/api/controllers/tools.controller.js
+++ b/packages/server/api/controllers/tools.controller.js
@@ -3,6 +3,7 @@ const HttpError = require('../lib/utils/http-error');
 
 const getTools = async () => {
   return knex('tools').select(
+    'id',
     'name',
     'time_frame_min',
     'time_frame_max',

--- a/packages/server/api/routes/favourites.router.js
+++ b/packages/server/api/routes/favourites.router.js
@@ -39,8 +39,15 @@ router.post('/', (req, res, next) => {
  *    tags: [Favourites]
  *    summary: Get all favourite tools
  *    description:
- *      Will return all favourite tools
+ *      Will return all favourite tools with matching user_id
  *    produces: application/json
+ *     parameters:
+ *        - in: body
+ *         name: id
+ *         schema:
+ *           type: integer
+ *           required: true
+ *           description: The user id
  *    responses:
  *      200:
  *        description: Successful request
@@ -50,7 +57,7 @@ router.post('/', (req, res, next) => {
 
 router.get('/', (req, res, next) => {
   favouritesController
-    .getAllFavourites()
+    .getAllFavourites(req.body.id)
     .then((result) => res.json(result))
     .catch(next);
 });

--- a/packages/server/api/routes/favourites.router.js
+++ b/packages/server/api/routes/favourites.router.js
@@ -1,0 +1,58 @@
+const express = require('express');
+const router = express.Router({ mergeParams: true });
+const favouritesController = require('../controllers/favourites.controller');
+
+/**
+ * @swagger
+ * tags:
+ *    name: Tools
+ *    description: Toolbox API
+ */
+
+/**
+ * @swagger
+ * /api/favorites:
+ *  post:
+ *    tags: [Favourites]
+ *    summary: Add favourite tools
+ *    description:
+ *      Will add tool to favourite table
+ *    produces: application/json
+ *    responses:
+ *      200:
+ *        description: Successful request
+ *      5XX:
+ *        description: Unexpected error
+ */
+
+router.post('/', (req, res, next) => {
+  favouritesController
+    .postFavorites(req.body)
+    .then((result) => res.json(result))
+    .catch(next);
+});
+
+/**
+ * @swagger
+ * /api/favorites:
+ *  get:
+ *    tags: [Favourites]
+ *    summary: Get all favourite tools
+ *    description:
+ *      Will return all favourite tools
+ *    produces: application/json
+ *    responses:
+ *      200:
+ *        description: Successful request
+ *      5XX:
+ *        description: Unexpected error
+ */
+
+router.get('/', (req, res, next) => {
+  favouritesController
+    .getAllFavourites()
+    .then((result) => res.json(result))
+    .catch(next);
+});
+
+module.exports = router;

--- a/packages/server/api/routes/favourites.router.js
+++ b/packages/server/api/routes/favourites.router.js
@@ -19,6 +19,19 @@ const favouritesController = require('../controllers/favourites.controller');
  *    description:
  *      Will add tool to favourite table
  *    produces: application/json
+ *    parameters:
+ *      - in: body
+ *        name: tool_id
+ *        schema:
+ *           type: integer
+ *           required: true
+ *           description: The tool id
+ *      - in: body
+ *        name: user_id
+ *        schema:
+ *           type: integer
+ *           required: true
+ *           description: The user id
  *    responses:
  *      200:
  *        description: Successful request
@@ -43,7 +56,7 @@ router.post('/', (req, res, next) => {
  *       Will return all favourite tools with matching user_id
  *     produces: application/json
  *     parameters:
- *      - in: body
+ *      - in: params
  *        name: id
  *        schema:
  *           type: integer
@@ -59,6 +72,42 @@ router.post('/', (req, res, next) => {
 router.get('/:id', (req, res, next) => {
   favouritesController
     .getAllUsersFavourites(req.params.id)
+    .then((result) => res.json(result))
+    .catch(next);
+});
+
+/**
+ * @swagger
+ * /favourites:
+ *   delete:
+ *     tags: [Favourites]
+ *     summary: Delete favourite tool for user
+ *     description:
+ *       Will delete favourite tool with matching user_id
+ *     produces: application/json
+ *     parameters:
+ *      - in: body
+ *        name: tool_id
+ *        schema:
+ *           type: integer
+ *           required: true
+ *           description: The tool id
+ *      - in: body
+ *        name: user_id
+ *        schema:
+ *           type: integer
+ *           required: true
+ *           description: The user id
+ *     responses:
+ *       200:
+ *         description: Successful request
+ *       5XX:
+ *         description: Unexpected error
+ */
+
+router.delete('/', (req, res, next) => {
+  favouritesController
+    .deleteFavourites(req.body)
     .then((result) => res.json(result))
     .catch(next);
 });

--- a/packages/server/api/routes/favourites.router.js
+++ b/packages/server/api/routes/favourites.router.js
@@ -1,12 +1,13 @@
 const express = require('express');
+
 const router = express.Router({ mergeParams: true });
 const favouritesController = require('../controllers/favourites.controller');
 
 /**
  * @swagger
  * tags:
- *    name: Tools
- *    description: Toolbox API
+ *    name: Favourites
+ *    description: Favourites API
  */
 
 /**
@@ -34,30 +35,30 @@ router.post('/', (req, res, next) => {
 
 /**
  * @swagger
- * /api/favorites:
- *  get:
- *    tags: [Favourites]
- *    summary: Get all favourite tools
- *    description:
- *      Will return all favourite tools with matching user_id
- *    produces: application/json
+ * /favourites/{id}:
+ *   get:
+ *     tags: [Favourites]
+ *     summary: Get all users favourite tools
+ *     description:
+ *       Will return all favourite tools with matching user_id
+ *     produces: application/json
  *     parameters:
- *        - in: body
- *         name: id
- *         schema:
+ *      - in: body
+ *        name: id
+ *        schema:
  *           type: integer
  *           required: true
  *           description: The user id
- *    responses:
- *      200:
- *        description: Successful request
- *      5XX:
- *        description: Unexpected error
+ *     responses:
+ *       200:
+ *         description: Successful request
+ *       5XX:
+ *         description: Unexpected error
  */
 
-router.get('/', (req, res, next) => {
+router.get('/:id', (req, res, next) => {
   favouritesController
-    .getAllFavourites(req.body.id)
+    .getAllUsersFavourites(req.params.id)
     .then((result) => res.json(result))
     .catch(next);
 });

--- a/packages/server/api/routes/index.js
+++ b/packages/server/api/routes/index.js
@@ -5,6 +5,7 @@ const router = express.Router();
 const exampleResources = require('./exampleResources.router');
 
 const tools = require('./tools.router');
+const favourites = require('./favourites.router');
 
 /* GET home page. */
 // router.get('/', function(req, res, next) {
@@ -37,5 +38,6 @@ router.use('/documentation', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 router.use('/exampleResources', exampleResources);
 
 router.use('/tools', tools);
+router.use('/favourites', favourites);
 
 module.exports = router;


### PR DESCRIPTION
Was implemented possibility to favorite and un-favorite tools. When clicking the “Favorites” link in the navigation, the tools grid only shows tools marked as favorite.

**This is first iteration of this task before Firebase is implemented. That's why user_id is hardcoded as =1 in code.** 

# How to test?
- run command  "docker compose up" in server folder
- run "yarn start" in server folder  
- run "yarn start" in client folder

Try to make tools favorite and mark them as unfavourite. Check “Favorites” link in the navigation

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the name conventions for CSS Classnames and filenames, Components names and filenames, Style filenames, if you are in doubt check the the project README.MD and here https://github.com/HackYourFuture-CPH/curriculum/blob/master/review/review-checklist.md
- [x] I have commented my code, particularly in hard-to-understand areas, if you code was simple enough mark the box anyway
- [x] I have made corresponding changes to the documentation, if you code was simple enough mark the box anyway
- [x] This PR is ready to be merged and not breaking any other functionality
