### PR TITLE
Bugfix/show all button logic

### DIFF
--- a/packages/client/src/components/FilteringArea/FilteringSection.js
+++ b/packages/client/src/components/FilteringArea/FilteringSection.js
@@ -11,14 +11,14 @@ export const FilteringSection = ({
   fetchKey,
   addQueryParam,
   removeQueryParam,
-  getAllTools,
+  removeAllQueryParamsFromFilteringSection,
 }) => {
   const [isShowAllSelected, setIsShowAllSelected] = useState(true);
 
   const iconLink = `/assets/vectors/${iconName}.svg`;
 
   const handleShowAll = (e) => {
-    getAllTools();
+    removeAllQueryParamsFromFilteringSection(fetchKey, options);
     setIsShowAllSelected(true);
     setSelectedOptions([]);
   };
@@ -101,7 +101,7 @@ FilteringSection.defaultProps = {
   fetchKey: '',
   addQueryParam: () => {},
   removeQueryParam: () => {},
-  getAllTools: () => {},
+  removeAllQueryParamsFromFilteringSection: () => {},
 };
 
 FilteringSection.propTypes = {
@@ -119,5 +119,5 @@ FilteringSection.propTypes = {
   fetchKey: PropTypes.string,
   addQueryParam: PropTypes.func,
   removeQueryParam: PropTypes.func,
-  getAllTools: PropTypes.func,
+  removeAllQueryParamsFromFilteringSection: PropTypes.func,
 };

--- a/packages/client/src/components/FilteringArea/FilteringSection.js
+++ b/packages/client/src/components/FilteringArea/FilteringSection.js
@@ -7,31 +7,25 @@ export const FilteringSection = ({
   iconName,
   checkboxName,
   selectedOptions,
-  setSelectedOptions,
   fetchKey,
-  addQueryParam,
-  removeQueryParam,
-  removeAllQueryParamsFromFilteringSection,
+  addFilter,
+  removeFilter,
+  clearFilters,
 }) => {
   const [isShowAllSelected, setIsShowAllSelected] = useState(true);
 
   const iconLink = `/assets/vectors/${iconName}.svg`;
 
   const handleShowAll = (e) => {
-    removeAllQueryParamsFromFilteringSection(fetchKey, options);
+    clearFilters(fetchKey, options);
     setIsShowAllSelected(true);
-    setSelectedOptions([]);
   };
 
   const handleCheck = (e) => {
-    if (selectedOptions.includes(e.target.id)) {
-      setSelectedOptions(
-        selectedOptions.filter((item) => item !== e.target.id),
-      );
-      removeQueryParam(e.target.value, fetchKey);
+    if (selectedOptions.includes(e.target.value)) {
+      removeFilter(e.target.value, fetchKey);
     } else {
-      setSelectedOptions((prevValue) => prevValue.concat(e.target.id));
-      addQueryParam(e.target.value, fetchKey);
+      addFilter(e.target.value, fetchKey);
       setIsShowAllSelected(false);
     }
   };
@@ -59,7 +53,7 @@ export const FilteringSection = ({
       <div className={`filtering-checkbox-mobile-view-for-${checkboxName}`}>
         {/* if the data from DB will be use instead of the data from config file, you can pass needed keys as props not to create a separate file for each filtering section  */}
         {options.map((option) => {
-          const isSelected = selectedOptions.includes(option.title);
+          const isSelected = selectedOptions.includes(`${option.id}`);
           return (
             <div className="filtering-checkbox-element" key={title + option.id}>
               <input
@@ -97,11 +91,10 @@ FilteringSection.defaultProps = {
   iconName: '',
   checkboxName: '',
   selectedOptions: [],
-  setSelectedOptions: () => {},
   fetchKey: '',
-  addQueryParam: () => {},
-  removeQueryParam: () => {},
-  removeAllQueryParamsFromFilteringSection: () => {},
+  addFilter: () => {},
+  removeFilter: () => {},
+  clearFilters: () => {},
 };
 
 FilteringSection.propTypes = {
@@ -115,9 +108,8 @@ FilteringSection.propTypes = {
   iconName: PropTypes.string,
   checkboxName: PropTypes.string,
   selectedOptions: PropTypes.arrayOf(PropTypes.string),
-  setSelectedOptions: PropTypes.func,
   fetchKey: PropTypes.string,
-  addQueryParam: PropTypes.func,
-  removeQueryParam: PropTypes.func,
-  removeAllQueryParamsFromFilteringSection: PropTypes.func,
+  addFilter: PropTypes.func,
+  removeFilter: PropTypes.func,
+  clearFilters: PropTypes.func,
 };

--- a/packages/client/src/components/FilteringArea/useFilteringSection.js
+++ b/packages/client/src/components/FilteringArea/useFilteringSection.js
@@ -2,15 +2,12 @@ import { useState, useMemo } from 'react';
 
 export function useFilteringSection() {
   const [options, setOptions] = useState([]);
-  const [selectedOptions, setSelectedOptions] = useState([]);
 
   return useMemo(
     () => ({
       options,
       setOptions,
-      selectedOptions,
-      setSelectedOptions,
     }),
-    [options, selectedOptions],
+    [options],
   );
 }

--- a/packages/client/src/containers/LandingPage/LandingPage.Container.js
+++ b/packages/client/src/containers/LandingPage/LandingPage.Container.js
@@ -14,7 +14,7 @@ import {
 } from './filterMockData';
 
 export const LandingPage = () => {
-  const { filterActions, tools } = useFilteredTools();
+  const { filterActions, tools, filters } = useFilteredTools();
   const categories = useFilteringSection();
   const numberOfParticipants = useFilteringSection();
   const timeframes = useFilteringSection();
@@ -31,6 +31,7 @@ export const LandingPage = () => {
     <div className="landing-page-container">
       <FilteringArea>
         <FilteringSection
+          selectedOptions={filters.category}
           {...categories}
           title="CATEGORY"
           iconName="vector-categories"
@@ -39,6 +40,7 @@ export const LandingPage = () => {
           {...filterActions}
         />
         <FilteringSection
+          selectedOptions={filters.participantsNumber}
           {...numberOfParticipants}
           title="NUMBER OF PARTICIPANTS"
           iconName="vector-people"
@@ -47,6 +49,7 @@ export const LandingPage = () => {
           {...filterActions}
         />
         <FilteringSection
+          selectedOptions={filters.timeframe}
           {...timeframes}
           title="TIME FRAME [minutes]"
           iconName="vector-clock"

--- a/packages/client/src/containers/LandingPage/useFilteredTools.js
+++ b/packages/client/src/containers/LandingPage/useFilteredTools.js
@@ -37,7 +37,6 @@ export function useFilteredTools() {
     setQueryString(`?${newQueryString}`);
   }, [filters]);
 
-  // Removing all already selected options that belongs to a showAll button
   const clearFilters = useCallback(
     (fetchKey) => {
       setFilters({
@@ -48,7 +47,6 @@ export function useFilteredTools() {
     [filters],
   );
 
-  // Modifying a query string, by adding a new query param. Triggers by pressing on a checkbox
   const addFilter = useCallback(
     (optionID, fetchKey) => {
       setFilters({
@@ -59,7 +57,6 @@ export function useFilteredTools() {
     [filters],
   );
 
-  // Modifying a query string, by deleting an already existing query param. Triggers by pressing on the same checkbox on a second time
   const removeFilter = useCallback(
     (optionID, fetchKey) => {
       setFilters({

--- a/packages/client/src/containers/LandingPage/useFilteredTools.js
+++ b/packages/client/src/containers/LandingPage/useFilteredTools.js
@@ -20,6 +20,40 @@ export function useFilteredTools() {
     });
   }, [baseUrl]);
 
+  // Removing all already selected options that belongs to a showAll button
+  const removeAllQueryParamsFromFilteringSection = useCallback(
+    (fetchKey, options) => {
+      let newUrl = baseUrl;
+      options.forEach((option) => {
+        const url = `${fetchKey}[]=${option.id}`;
+
+        // All possible query params
+        const queryParams = {
+          queryParamBeginWithQuestionMark: `?${url}`,
+          queryParamBeginWithAmpersand: `&${url}`,
+          queryParamEndWithAmpersand: `${url}&`,
+        };
+
+        function checkIfBaseUrlAlreadyIncludeQueryParamToDelete(queries) {
+          for (const key in queryParams) {
+            if (Object.hasOwnProperty.call(queryParams, key)) {
+              const element = queryParams[key];
+              const isInclude = baseUrl.includes(element);
+              if (isInclude) {
+                const updatedUrl = newUrl.replace(element, '');
+                newUrl = updatedUrl;
+                return;
+              }
+            }
+          }
+        }
+        checkIfBaseUrlAlreadyIncludeQueryParamToDelete(queryParams);
+      });
+      setBaseUrl(newUrl);
+    },
+    [baseUrl],
+  );
+
   // Modifying a query string, by adding a new query param. Triggers by pressing on a checkbox
   const addQueryParam = useCallback(
     (optionID, fetchKey) => {
@@ -89,8 +123,20 @@ export function useFilteredTools() {
   return useMemo(
     () => ({
       tools: { tools, isLoading },
-      filterActions: { getAllTools, addQueryParam, removeQueryParam },
+      filterActions: {
+        getAllTools,
+        addQueryParam,
+        removeQueryParam,
+        removeAllQueryParamsFromFilteringSection,
+      },
     }),
-    [addQueryParam, getAllTools, isLoading, removeQueryParam, tools],
+    [
+      addQueryParam,
+      getAllTools,
+      isLoading,
+      removeQueryParam,
+      removeAllQueryParamsFromFilteringSection,
+      tools,
+    ],
   );
 }


### PR DESCRIPTION
# Description

Bugfix. Changed showAll button and checkboxes behavior. Instead of just modifying the query string, we gonna use an object state with arrays of strings that cover every selected filter option in every filtering section. A query string to fetch all tools created from all queries inside of the object. By clicking on a checkbox we pass a string (a query param) into the array that match that filtering section. Show all button gonna remove all query params belongs to a filtering section.

Fixes # (issue)

# How to test?

Start the client side of the project and checkout localhost:3000

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have followed the name conventions for CSS Classnames and filenames, Components names and filenames, Style filenames, if you are in doubt check the the project README.MD and here https://github.com/HackYourFuture-CPH/curriculum/blob/master/review/review-checklist.md
- [ ] I have commented my code, particularly in hard-to-understand areas, if you code was simple enough mark the box anyway
- [ ] I have made corresponding changes to the documentation, if you code was simple enough mark the box anyway
- [ ] This PR is ready to be merged and not breaking any other functionality
