### PR TITLE
FP21-134-navigation-align-links-hide-on-mobile

### DIFF
--- a/packages/client/src/components/Navigation/Navbar.css
+++ b/packages/client/src/components/Navigation/Navbar.css
@@ -83,7 +83,7 @@ header > * {
 .favourite-container,
 .navbar-links-container {
   display: flex;
-  align-items: center;
+  align-items: flex-end;
   justify-content: flex-end;
 }
 
@@ -101,7 +101,7 @@ header > * {
   font-size: 1.25rem;
   text-decoration: none;
   display: flex;
-  align-items: center;
+  align-items: flex-end;
 }
 
 .navbar-icon {
@@ -148,12 +148,23 @@ header > * {
   .user-name-container {
     margin-right: 1.5rem;
   }
+
+  .navbar-link,
+  .navbar-button,
+  .user-name-container {
+    font-size: 1.1rem;
+  }
+
+  .logo a {
+    font-size: 1.65rem;
+  }
 }
 
 @media screen and (max-width: 1230px) {
   .navbar-links-container > .navbar-link,
   .navbar-link span,
-  .user-name-container span {
+  .log-in-container span,
+  .log-out-container span {
     display: none;
   }
 
@@ -237,7 +248,7 @@ header > * {
 
 @media screen and (max-width: 400px) {
   .logo a {
-    font-size: 1rem;
+    font-size: 0.9rem;
   }
 }
 


### PR DESCRIPTION
Links in Navigation near icons **sign-in**, **sign out**, **favourites** aligned to the bottom in accordance with design changes. 
Fixed hiding sign-in sign-out links text on mobile view. 

# How to test?

Run frontend and check on mobile view.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the name conventions for CSS Classnames and filenames, Components names and filenames, Style filenames, if you are in doubt check the the project README.MD and here https://github.com/HackYourFuture-CPH/curriculum/blob/master/review/review-checklist.md
- [x] I have commented my code, particularly in hard-to-understand areas, if you code was simple enough mark the box anyway
- [x] I have made corresponding changes to the documentation, if you code was simple enough mark the box anyway
- [x] This PR is ready to be merged and not breaking any other functionality
