### PR TITLE
FP21-139: Nothing found case for tool grid

### DIFF
--- a/packages/client/src/components/SearchBar/SearchBar.css
+++ b/packages/client/src/components/SearchBar/SearchBar.css
@@ -33,6 +33,7 @@
 .searchBarDiv {
   position: relative;
   width: 30rem;
+  height: 5rem;
   margin: 1.563rem auto;
 }
 
@@ -40,7 +41,7 @@
   position: absolute;
   left: 1rem;
   pointer-events: none;
-  top: 50%;
+  top: 27%;
   transform: translateY(-50%);
 }
 
@@ -48,9 +49,17 @@
   display: none;
 }
 
+.search-result-null {
+  font-size: 12px;
+}
+
 @media screen and (max-width: 559px) {
   .searchBarDiv {
     width: calc(100% - 0.9rem);
     margin: 0.95rem auto;
+  }
+
+  .search-result-null {
+    line-height: normal;
   }
 }

--- a/packages/client/src/components/SearchBar/SearchBar.js
+++ b/packages/client/src/components/SearchBar/SearchBar.js
@@ -2,7 +2,10 @@ import React from 'react';
 import './SearchBar.css';
 import PropTypes from 'prop-types';
 
-export default function SearchBar({ filterByToolNameAction }) {
+export default function SearchBar({
+  filterByToolNameAction,
+  searchResultNull,
+}) {
   return (
     <div className="searchBarDiv">
       <input
@@ -12,11 +15,18 @@ export default function SearchBar({ filterByToolNameAction }) {
         onChange={(e) => filterByToolNameAction(e.target.value)}
       />
       <img src="/assets/vectors/vector-search.svg" alt="search icon" />
+      {searchResultNull ? (
+        <p className="search-result-null">
+          The tool has not been found. Make sure the spelling is correct or try
+          different keywords.
+        </p>
+      ) : null}
     </div>
   );
 }
 SearchBar.propTypes = {
   filterByToolNameAction: PropTypes.func,
+  searchResultNull: PropTypes.bool.isRequired,
 };
 
 SearchBar.defaultProps = {

--- a/packages/client/src/components/ToolsGrid/ToolsGrid.component.js
+++ b/packages/client/src/components/ToolsGrid/ToolsGrid.component.js
@@ -56,7 +56,7 @@ export const ToolsGrid = ({
         <Loader />
       </div>
     );
-  } else if (isLoading === false && sortedTools.length !== 0) {
+  } else if (!isLoading && sortedTools.length !== 0) {
     setSearchResultNull(false);
     toolsToRender = (
       <div className="grid-tools-container">

--- a/packages/client/src/components/ToolsGrid/ToolsGrid.component.js
+++ b/packages/client/src/components/ToolsGrid/ToolsGrid.component.js
@@ -69,7 +69,7 @@ export const ToolsGrid = ({
     toolsToRender = (
       <div className="no-tools-message">
         <p>
-          No tools has been found.
+          No tools have been found.
           <br /> Please try another filtering option(s) or/and different
           keywords
         </p>

--- a/packages/client/src/components/ToolsGrid/ToolsGrid.component.js
+++ b/packages/client/src/components/ToolsGrid/ToolsGrid.component.js
@@ -1,11 +1,16 @@
 import React, { useState, useMemo } from 'react';
-import PropTypes from 'prop-types';
+import PropTypes, { func } from 'prop-types';
 import './ToolsGrid.style.css';
 import { ToolItem } from '../ToolItem/ToolItem.component';
 import { Sorting } from '../Sorting/Sorting.component';
 import { Loader } from '../Loader/Loader.component';
 
-export const ToolsGrid = ({ searchBarText, tools, isLoading }) => {
+export const ToolsGrid = ({
+  searchBarText,
+  tools,
+  isLoading,
+  setSearchResultNull,
+}) => {
   const [selected, setSelected] = useState('');
   const sortedTools = useMemo(() => {
     let result = tools;
@@ -13,6 +18,11 @@ export const ToolsGrid = ({ searchBarText, tools, isLoading }) => {
       result = result.filter((tooltomap) =>
         tooltomap.name.toLowerCase().includes(searchBarText.toLowerCase()),
       );
+      if (result.length === 0) {
+        setSearchResultNull(true);
+      } else {
+        setSearchResultNull(false);
+      }
       return result;
     }
     if (selected === 'a-z') {
@@ -35,24 +45,41 @@ export const ToolsGrid = ({ searchBarText, tools, isLoading }) => {
       });
     }
     return result;
-  }, [tools, selected, searchBarText]);
+  }, [tools, selected, searchBarText, setSearchResultNull]);
 
-  const toolsToRender = isLoading ? (
-    <div className="LoadingMessage">
-      <span>Loading tool...</span>
-      <Loader />
-    </div>
-  ) : (
-    <div className="grid-tools-container">
-      {sortedTools.map((tool, i) => {
-        return <ToolItem index={i} key={tool.id} tool={tool} />;
-      })}
-    </div>
-  );
+  let toolsToRender;
+
+  if (isLoading) {
+    toolsToRender = (
+      <div className="LoadingMessage">
+        <span>Loading tool...</span>
+        <Loader />
+      </div>
+    );
+  } else if (isLoading === false && sortedTools.length !== 0) {
+    setSearchResultNull(false);
+    toolsToRender = (
+      <div className="grid-tools-container">
+        {sortedTools.map((tool, i) => {
+          return <ToolItem index={i} key={tool.id} tool={tool} />;
+        })}
+      </div>
+    );
+  } else {
+    toolsToRender = (
+      <div className="no-tools-message">
+        <p>
+          No tools has been found.
+          <br /> Please try another filtering option(s) or/and different
+          keywords
+        </p>
+      </div>
+    );
+  }
 
   return (
     <div>
-      <Sorting setSelected={setSelected} />
+      {sortedTools.length !== 0 ? <Sorting setSelected={setSelected} /> : null}
       <div>{toolsToRender}</div>
     </div>
   );
@@ -60,10 +87,12 @@ export const ToolsGrid = ({ searchBarText, tools, isLoading }) => {
 
 ToolsGrid.defaultProps = {
   searchBarText: null,
+  setSearchResultNull: func,
 };
 
 ToolsGrid.propTypes = {
   searchBarText: PropTypes.string,
   tools: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   isLoading: PropTypes.bool.isRequired,
+  setSearchResultNull: PropTypes.func,
 };

--- a/packages/client/src/components/ToolsGrid/ToolsGrid.style.css
+++ b/packages/client/src/components/ToolsGrid/ToolsGrid.style.css
@@ -5,6 +5,11 @@
   grid-gap: 0.625rem;
 }
 
+.no-tools-message {
+  height: 44px;
+  padding: 66px 20px 0px 20px;
+}
+
 @media screen and (max-width: 820px) {
   .grid-tools-container {
     grid-template-columns: repeat(2, 1fr);

--- a/packages/client/src/containers/LandingPage/LandingPage.Container.js
+++ b/packages/client/src/containers/LandingPage/LandingPage.Container.js
@@ -17,6 +17,7 @@ import {
 
 export const LandingPage = () => {
   const [searchBarText, setSearchBarText] = useState('');
+  const [searchResultNull, setSearchResultNull] = useState(false);
 
   const filterByToolName = (value) => {
     setSearchBarText(value);
@@ -37,7 +38,10 @@ export const LandingPage = () => {
   return (
     <div className="landing-page-container">
       <WelcomeBox />
-      <SearchBar filterByToolNameAction={filterByToolName} />
+      <SearchBar
+        filterByToolNameAction={filterByToolName}
+        searchResultNull={searchResultNull}
+      />
       <FilteringArea>
         <FilteringSection
           selectedOptions={filters.category}
@@ -67,7 +71,11 @@ export const LandingPage = () => {
           {...filterActions}
         />
       </FilteringArea>
-      <ToolsGrid {...tools} searchBarText={searchBarText} />
+      <ToolsGrid
+        {...tools}
+        searchBarText={searchBarText}
+        setSearchResultNull={setSearchResultNull}
+      />
     </div>
   );
 };


### PR DESCRIPTION
# Description

Hint for the cases with no tools found when filtering or/and searching for a tool has been added. So a user will see "Nothing found"  message if no tools are found. 


<img width="652" alt="notools" src="https://user-images.githubusercontent.com/73354989/185780872-a58254e6-d2c3-4e42-9335-66890dc0026f.png">
<img width="648" alt="notools2" src="https://user-images.githubusercontent.com/73354989/185780907-fd9df6ce-f3f9-4749-a3c6-a7e9e682a5a4.png">


# How to test?

Run BE and FE and try searching for some nonsence or filtering tools with random options.


# Checklist

✅  I have performed a self-review of my own code
✅ I have followed the name conventions for CSS Classnames and filenames, Components names and filenames, Style filenames, if you are in doubt check the the project README.MD and here https://github.com/HackYourFuture-CPH/curriculum/blob/master/review/review-checklist.md
✅ I have commented my code, particularly in hard-to-understand areas, if you code was simple enough mark the box anyway
✅ I have made corresponding changes to the documentation, if you code was simple enough mark the box anyway
✅This PR is ready to be merged and not breaking any other functionality
