### PR TITLE
seed for tool_categories fixed

### DIFF
--- a/packages/server/seeds/development/03_tools_categories.js
+++ b/packages/server/seeds/development/03_tools_categories.js
@@ -4,78 +4,99 @@
  */
 
 exports.seed = async function (knex) {
-  await knex('tools_categories').insert([
-    {
-      tool_id: 1,
-      category_id: 3,
-    },
-    {
-      tool_id: 2,
-      category_id: 1,
-    },
-    {
-      tool_id: 3,
-      category_id: 1,
-    },
-    {
-      tool_id: 3,
-      category_id: 3,
-    },
-    {
-      tool_id: 4,
-      category_id: 1,
-    },
-    {
-      tool_id: 4,
-      category_id: 4,
-    },
-    {
-      tool_id: 5,
-      category_id: 3,
-    },
-    {
-      tool_id: 6,
-      category_id: 3,
-    },
-    {
-      tool_id: 6,
-      category_id: 1,
-    },
-    {
-      tool_id: 7,
-      category_id: 1,
-    },
-    {
-      tool_id: 7,
-      category_id: 3,
-    },
-    {
-      tool_id: 8,
-      category_id: 2,
-    },
-    {
-      tool_id: 8,
-      category_id: 3,
-    },
-    {
-      tool_id: 9,
-      category_id: 1,
-    },
-    {
-      tool_id: 10,
-      category_id: 3,
-    },
-    {
-      tool_id: 11,
-      category_id: 4,
-    },
-    {
-      tool_id: 11,
-      category_id: 1,
-    },
-    {
-      tool_id: 12,
-      category_id: 3,
-    },
-  ]);
+  await knex('tools_categories')
+    .insert([
+      {
+        id: 1,
+        tool_id: 1,
+        category_id: 3,
+      },
+      {
+        id: 2,
+        tool_id: 2,
+        category_id: 1,
+      },
+      {
+        id: 3,
+        tool_id: 3,
+        category_id: 1,
+      },
+      {
+        id: 4,
+        tool_id: 3,
+        category_id: 3,
+      },
+      {
+        id: 5,
+        tool_id: 4,
+        category_id: 1,
+      },
+      {
+        id: 6,
+        tool_id: 4,
+        category_id: 4,
+      },
+      {
+        id: 7,
+        tool_id: 5,
+        category_id: 3,
+      },
+      {
+        id: 8,
+        tool_id: 6,
+        category_id: 3,
+      },
+      {
+        id: 9,
+        tool_id: 6,
+        category_id: 1,
+      },
+      {
+        id: 10,
+        tool_id: 7,
+        category_id: 1,
+      },
+      {
+        id: 11,
+        tool_id: 7,
+        category_id: 3,
+      },
+      {
+        id: 12,
+        tool_id: 8,
+        category_id: 2,
+      },
+      {
+        id: 13,
+        tool_id: 8,
+        category_id: 3,
+      },
+      {
+        id: 14,
+        tool_id: 9,
+        category_id: 1,
+      },
+      {
+        id: 15,
+        tool_id: 10,
+        category_id: 3,
+      },
+      {
+        id: 16,
+        tool_id: 11,
+        category_id: 4,
+      },
+      {
+        id: 17,
+        tool_id: 11,
+        category_id: 1,
+      },
+      {
+        id: 18,
+        tool_id: 12,
+        category_id: 3,
+      },
+    ])
+    .onConflict('id')
+    .merge();
 };


### PR DESCRIPTION
Seed file for table tools_categories was fixed, so now it will not be duplication of tool categories connection.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the name conventions for CSS Classnames and filenames, Components names and filenames, Style filenames, if you are in doubt check the the project README.MD and here https://github.com/HackYourFuture-CPH/curriculum/blob/master/review/review-checklist.md
- [x] I have commented my code, particularly in hard-to-understand areas, if you code was simple enough mark the box anyway
- [x] I have made corresponding changes to the documentation, if you code was simple enough mark the box anyway
- [x] This PR is ready to be merged and not breaking any other functionality
