### PR TITLE
FP21-148-delete-tool-for-admin Added Delete and Edit buttons for the …

### DIFF
--- a/packages/client/src/App.js
+++ b/packages/client/src/App.js
@@ -17,6 +17,7 @@ import { ContactUs } from './components/ContactUs/ContactUs/ContactUs.component'
 import { Inbox } from './components/InboxMessageAdmin/Inbox.component';
 import { AuthContextProvider, UserAuth } from './firebase/AuthContext';
 import { AboutToolbox } from './components/AboutToolbox/AboutToolbox.component';
+import { DeleteConfirmation } from './components/DeleteToolConfirmation/DeleteToolConfirmation.component';
 
 const Wrapper = ({ children }) => {
   const location = useLocation();
@@ -60,6 +61,11 @@ const RouteList = () => {
       <Route path="/contact-us" element={<ContactUs />} />
       <Route path="/user-name" element="" />
       <Route path="/favourites" element={<FavouritePage />} />
+      <Route
+        path="/tools/delete-confirmation/:id"
+        element={<DeleteConfirmation />}
+      />
+      <Route path="/tools/edit/:id" element="" />
       {localUser && localUser.is_admin && (
         <Route path="/inbox-admin" element={<Inbox />} />
       )}

--- a/packages/client/src/components/DeleteToolConfirmation/DeleteToolConfirmation.component.js
+++ b/packages/client/src/components/DeleteToolConfirmation/DeleteToolConfirmation.component.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import { Link, useLocation } from 'react-router-dom';
+import './DeleteToolConfirmation.style.css';
+import getApiBaseUrl from '../../utils/getApiBaseURL';
+import { UserAuth } from '../../firebase/AuthContext';
+
+export const DeleteConfirmation = () => {
+  const location = useLocation();
+  const { id } = location.state;
+  const { user } = UserAuth();
+  function deleteToolByFetch() {
+    fetch(`${getApiBaseUrl()}/admin/tools/${id}`, {
+      method: 'DELETE',
+      headers: {
+        authorization: `Bearer ${user.accessToken}`,
+      },
+    }).then((res) => {
+      if (res.ok) {
+        // eslint-disable-next-line
+        alert('success!!  deleted');
+      }
+      // eslint-disable-next-line
+      alert(`Error deleting ${res.status}`);
+    }); // eslint-disable-next-line no-console
+    console.log('deletebyfetch');
+  }
+  const handleDelete = (e) => {
+    // eslint-disable-next-line no-console
+    console.log('handleDelete');
+    e.preventDefault();
+    deleteToolByFetch();
+  };
+  return (
+    <>
+      <h1>Delete the tool is non-reversible, click DELETE to confirm. </h1>
+      <div className="delete-tool-confirmation-button-container">
+        <button
+          type="button"
+          onClick={handleDelete}
+          className="confirm-delete-tool-button"
+        >
+          DELETE
+        </button>
+        <button type="button" className="cancel-ddelete-tool-button">
+          <Link to="/">CANCEL</Link>
+        </button>
+      </div>
+    </>
+  );
+};

--- a/packages/client/src/components/DeleteToolConfirmation/DeleteToolConfirmation.style.css
+++ b/packages/client/src/components/DeleteToolConfirmation/DeleteToolConfirmation.style.css
@@ -1,0 +1,45 @@
+.confirm-delete-tool-button,
+.cancel-ddelete-tool-button {
+  display: flex;
+  font-family: 'Abel';
+  font-style: normal;
+  background-color: inherit;
+  text-align: center;
+  letter-spacing: 0.05em;
+  height: calc(100% - 0.625rem);
+  width: 100%;
+  font-size: 1.8rem;
+  color: rgba(245, 245, 245, 1);
+  border: none;
+  padding: 0;
+  background: transparent;
+  align-items: center;
+  justify-content: center;
+}
+.delete-tool-confirmation-button-container {
+  position: relative;
+  background-color: rgba(0, 0, 0, 0.3);
+  display: flex;
+  align-items: flex-end;
+}
+.delete-tool-confirmation-button-container button {
+  border: 4px solid rgba(0, 0, 0, 0.2);
+}
+.delete-tool-confirmation-button-container::before {
+  width: 100%;
+  height: 0.625rem;
+  display: block;
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  background-image: url('../../../public/assets/images/tape-cut392.png');
+  background-repeat: no-repeat;
+  background-size: cover;
+}
+
+.confirm-delete-tool-button a,
+.cancel-ddelete-tool-button a {
+  color: rgba(245, 245, 245, 1);
+  text-decoration: none;
+}

--- a/packages/client/src/components/ToolItem/ToolItem.component.js
+++ b/packages/client/src/components/ToolItem/ToolItem.component.js
@@ -7,6 +7,7 @@ import { UserAuth } from '../../firebase/AuthContext';
 
 export const ToolItem = ({ tool }) => {
   const { userId } = UserAuth();
+  const { localUser } = UserAuth();
   const title = tool.name;
   const { picture } = tool;
   const { id } = tool;
@@ -120,13 +121,30 @@ export const ToolItem = ({ tool }) => {
         </div>
       </div>
 
-      <Link to={`/tools/${tool.id}`}>
+      {localUser && localUser.is_admin ? (
         <div className="button-container">
           <button type="button" className="tool-button">
-            VIEW TOOL
+            <Link to={`/tools/${tool.id}`}>VIEW TOOL</Link>
+          </button>
+          <button type="button" className="tool-button delete-tool">
+            <Link
+              to={`/tools/delete-confirmation/${tool.id}`}
+              state={{ id: tool.id }}
+            >
+              DELETE TOOL
+            </Link>
+          </button>
+          <button type="button" className="tool-button edit-tool">
+            <Link to={`/tools/edit/${tool.id}`}>EDIT TOOL</Link>
           </button>
         </div>
-      </Link>
+      ) : (
+        <div className="button-container">
+          <button type="button" className="tool-button">
+            <Link to={`/tools/${tool.id}`}>VIEW TOOL</Link>
+          </button>
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
…Admin user, and created Delete confirmation page

# Description

This PR contains:
1-) Delete and Edit buttons in the toolItem for the Admin user.
2-) Delete confirmation page.
The edit button do nothing, because we don't have edite form ready to link to it.
The delete confirmation button now give error, because deleting api should be fixed to contain deleting fron Tools-Categories table also.

Fixes # (issue)

# How to test?

run docker,server,client

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have followed the name conventions for CSS Classnames and filenames, Components names and filenames, Style filenames, if you are in doubt check the the project README.MD and here https://github.com/HackYourFuture-CPH/curriculum/blob/master/review/review-checklist.md
- [ ] I have commented my code, particularly in hard-to-understand areas, if you code was simple enough mark the box anyway
- [ ] I have made corresponding changes to the documentation, if you code was simple enough mark the box anyway
- [ ] This PR is ready to be merged and not breaking any other functionality
