### PR TITLE
bugfix/filtering-area-ui

### DIFF
--- a/packages/client/src/components/FilteringArea/FilteringArea.css
+++ b/packages/client/src/components/FilteringArea/FilteringArea.css
@@ -78,6 +78,7 @@
   cursor: pointer;
 }
 
+.searchBarDiv,
 .filtering-checkbox-element,
 .show-all-button {
   z-index: 1;

--- a/packages/client/src/components/FilteringArea/FilteringArea.css
+++ b/packages/client/src/components/FilteringArea/FilteringArea.css
@@ -78,6 +78,11 @@
   cursor: pointer;
 }
 
+.filtering-checkbox-element,
+.show-all-button {
+  z-index: 1;
+}
+
 .filtering-option {
   width: calc(100%-8px);
   height: 2rem;


### PR DESCRIPTION
# Description

The bug with filtering options buttons and searchbar not being active - due to a conflict between z-index and mix-blend-mode -  is now fixed

# How to test?

Run the app and try selecting filtering options or typing something in the search bar

# Checklist

✅ I have performed a self-review of my own code
✅ I have followed the name conventions for CSS Classnames and filenames, Components names and filenames, Style filenames, if you are in doubt check the the project README.MD and here https://github.com/HackYourFuture-CPH/curriculum/blob/master/review/review-checklist.md
✅I have commented my code, particularly in hard-to-understand areas, if you code was simple enough mark the box anyway
✅ I have made corresponding changes to the documentation, if you code was simple enough mark the box anyway
✅ This PR is ready to be merged and not breaking any other functionality
