### PR TITLE
bugfix for buttons outline and navigation links

### DIFF
--- a/packages/client/src/components/MobileNavigation/MobileNavigation.css
+++ b/packages/client/src/components/MobileNavigation/MobileNavigation.css
@@ -34,3 +34,7 @@
   text-decoration: none;
   font-family: 'Abel', sans-serif;
 }
+
+.mobile-navigation a:first-child {
+  margin-bottom: 0.5rem;
+}

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -7,6 +7,7 @@ body {
     Ubuntu, Cantarell, 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 }
 
 code {
@@ -41,4 +42,10 @@ a {
 
 ::-webkit-scrollbar-thumb:hover {
   background: rgba(255, 166, 0, 90%);
+}
+
+img:focus-visible,
+a:focus-visible,
+button:focus-visible {
+  outline: none;
 }


### PR DESCRIPTION
# Description
Bugfix for buttons outlines and navigation links space for mobile view


On image you can see the problem.

![image (2)](https://user-images.githubusercontent.com/93525817/186209269-c0012927-909e-4f03-a181-79b2c6e16f58.png)


# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have followed the name conventions for CSS Classnames and filenames, Components names and filenames, Style filenames, if you are in doubt check the the project README.MD and here https://github.com/HackYourFuture-CPH/curriculum/blob/master/review/review-checklist.md
- [ ] I have commented my code, particularly in hard-to-understand areas, if you code was simple enough mark the box anyway
- [ ] I have made corresponding changes to the documentation, if you code was simple enough mark the box anyway
- [ ] This PR is ready to be merged and not breaking any other functionality
